### PR TITLE
Make pack command work also on most non-english systems

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -60,7 +60,7 @@ function pushFiles(files, done) {
 
 function findNupkgs(stdout) {
   var matches = [];
-  var nupkg = new RegExp('\'(.+\.nupkg)\'', 'ig');
+  var nupkg = new RegExp('[\'"„“](.+\.nupkg)[\'"”]', 'ig');
 
   var match = nupkg.exec(stdout);
 


### PR DESCRIPTION
Unfortunately, nuget.exe writes localized output to stdout, and forcing it to stick to English will only work from [version 3.5 upwards](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.CommandLine/Program.cs#L18). This breaks packaging on systems where the output looks differently than expected. For example, in German, [double quotes](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Clients/NuGet.CommandLine/NuGetResources.resx#L744) instead of single quotes are used.

With the suggested change in this PR more languages, while still not all of them, will be supported.