### PR TITLE
Add verbosity option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ var options = {
   properties: 'configuration=release',
   minClientVersion: '2.5',
   msBuildVersion: '12',
+  verbosity: 'normal',
   build: true,
   symbols: true,
   excludeEmptyDirectories: true,
@@ -141,7 +142,8 @@ var options = {
   source: 'http://your-nuget-feed.org',
   apiKey: 'secret-key-goes-here',
   timeout: '300',
-  configFile: '%AppData%/NuGet/NuGet.config'
+  configFile: '%AppData%/NuGet/NuGet.config',
+  verbosity: 'normal',
 };
 
 var stream = nuget.push(options);
@@ -200,6 +202,7 @@ var options = {
   packagesDirectory: './packages',
   solutionDirectory: './',
   msBuildVersion: '12',
+  verbosity: 'normal',
   noCache: true,
   requireConsent: true,
   disableParallelProcessing: true

--- a/lib/argsFor.js
+++ b/lib/argsFor.js
@@ -19,7 +19,8 @@ exports.pack = function(nuspecFile, options) {
 		'exclude',
 		'properties',
 		'minClientVersion',
-		'msBuildVersion'
+		'msBuildVersion',
+		'verbosity'
 	];
 
 	withValues.forEach(function(prop) {
@@ -50,7 +51,8 @@ exports.push = function(nupkg, options) {
 		'source',
 		'apiKey',
 		'timeout',
-		'configFile'
+		'configFile',
+		'verbosity'
 	];
 
 	withValues.forEach(function(prop) {
@@ -74,7 +76,8 @@ exports.restore = function(nupkg, options) {
 		'configFile',
 		'packagesDirectory',
 		'solutionDirectory',
-		'msBuildVersion'
+		'msBuildVersion',
+		'verbosity'
 	];
 
 	var withoutValues = [


### PR DESCRIPTION
It would be nice to control the verbosity of the output from NuGet (in our scripts, we set it to _quiet_ when doing builds during development, and _detailed_ when doing a production build on the CI server).

Hope it helps!