### PR TITLE
Fix issue when file.basename isn't set

### DIFF
--- a/lib/validFor.js
+++ b/lib/validFor.js
@@ -11,7 +11,7 @@ exports.pack = function(file) {
 };
 
 exports.restore = function(file) {
-  var basename = file.basename || '';
+  var basename = path.basename(file.path);
   if(basename.match(/^(packages\.config|project\.json)$/i)) {
     return true;
   }

--- a/lib/validFor.js
+++ b/lib/validFor.js
@@ -16,7 +16,7 @@ exports.restore = function(file) {
     return true;
   }
 
-  var msg = file.path + ' is not supported. Supported files for nuget restore are: package.config, *.sln., project.json';
+  var msg = file.path + ' is not supported. Supported files for nuget restore are: packages.config, *.sln., project.json';
   var regexp = /^(\.sln)$/i;
 
   return supported(file, regexp, msg);


### PR DESCRIPTION
`file.basename` isn't guaranteed to be set, and, in that case, a `packages.config` or `project.json` file will be marked as invalid.

I was running into this error message:
>[09:49:03] C:\inetpub\wwwroot\test_gen\Website\Portals\_default\Skins\Costanza\packages.configC:\inetpub\wwwroot\test_gen\Website\Portals\_default\Skins\Costanza\packages.config is not supported. Supported files for nuget restore are: package.config, *.sln., project.json

Using code that's basically just a straightforward usage of the `restore` task:
```
gulp.src('**/packages.config')
    .pipe(nuget,restore({
        verbosity: nugetVerbosity,
        configFile: findNugetConfig(),
        packagesDirectory: packagesDir,
    }));
```