### PR TITLE
Fix #20 - Update ansi-styles to version 2.2.1.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
-      "version": "2.2.0",
+      "version": "2.2.1",
       "from": "ansi-styles@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "array-differ": {
       "version": "1.0.0",


### PR DESCRIPTION
This is necessary because version 2.2.0 has been withdrawn from npm, making it impossible to run `npm install` on any project that uses gulp-nuget.